### PR TITLE
Proposition pour éviter les dérives

### DIFF
--- a/src/Utils.php
+++ b/src/Utils.php
@@ -2,9 +2,11 @@
 
 namespace Felix\Flash;
 
-class Utils
+abstract class Utils
 {
-
+    /**
+     * @internal
+     */
     public static function array_flatten($array = null): array
     {
         $result = array();


### PR DESCRIPTION
Pour éviter qu'une classe de ce type soit utilisée n'importe comment, je la défini en `abstract` avec un PHPDoc `@internal`.
Pas de regret donc si elle change pour X raisons.